### PR TITLE
elimina carateres no estandar del titulo de la hoja. #65

### DIFF
--- a/src/main/java/chasqui/view/composer/XlsExporter.java
+++ b/src/main/java/chasqui/view/composer/XlsExporter.java
@@ -279,6 +279,7 @@ public class XlsExporter {
 			titulo = pedido.getCliente().getNombre() + " " + pedido.getCliente().getApellido();
 			titulo = msj + titulo;
 		}
+		titulo = titulo.replaceAll("[^a-zA-Z0-9 ]", "");
 		sheet = wb.createSheet(page.toString() + "_" + titulo);
 		PrintSetup printSetup = sheet.getPrintSetup();
 		printSetup.setLandscape(true);


### PR DESCRIPTION
- Se reemplaza los caracteres no estandar del titulo de una sheet  en la exportacion
- Para evitar exception al exportar
- Ojo se eliminan tambien letras con acentos y ñ